### PR TITLE
Updated prolarr ports to "go via" VPN

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       - 5080:5080
       - 6881:6881
       - 6881:6881/udp
+      # prowlarr ports
+      - 9696:9696
       # Transmission ports. Uncomment below if Transmission is used with VPN
       # - 9091:9091
       # - 51413:51413
@@ -171,8 +173,6 @@ services:
       - TZ=UTC
     volumes:
       - prowlarr-config:/config
-    ports:
-      - 9696:9696
     restart: unless-stopped
 
   jellyfin:


### PR DESCRIPTION
Hopefully fixing the issue mentioned in the comment on commit bf1cd779310ff4e119a1a4e1b6c4a1b793e501ce

Error response from daemon: conflicting options: port publishing and the container type network mode